### PR TITLE
Fix: Laravel minimum versions

### DIFF
--- a/.github/workflows/formats.yml
+++ b/.github/workflows/formats.yml
@@ -2,10 +2,16 @@ name: Formats
 
 on:
   push:
+    paths-ignore:
+      - "**.md"
+      - "docs/**"
     branches:
       - main
       - ci/test
   pull_request:
+    paths-ignore:
+      - "**.md"
+      - "docs/**"
 
 jobs:
   formats:
@@ -15,10 +21,9 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
-        php: [8.2, 8.3, 8.4]
-        dependency-version: [prefer-lowest, prefer-stable]
+        php: ["8.2", "8.3", "8.4"]
 
-    name: Formats P${{ matrix.php }} - ${{ matrix.os }} - ${{ matrix.dependency-version }}
+    name: PHP${{ matrix.php }} - ${{ matrix.os }}
 
     steps:
       - name: Checkout
@@ -41,10 +46,10 @@ jobs:
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: dependencies-php-${{ matrix.php }}-os-${{ matrix.os }}-version-${{ matrix.dependency-version }}-composer-${{ hashFiles('composer.json') }}
-          restore-keys: dependencies-php-${{ matrix.php }}-os-${{ matrix.os }}-version-${{ matrix.dependency-version }}-composer-
+          restore-keys: dependencies-php-${{ matrix.php }}-os-${{ matrix.os }}-version-
 
       - name: Install Composer dependencies
-        run: composer update --${{ matrix.dependency-version }} --no-interaction --prefer-dist
+        run: composer update --no-interaction --prefer-dist
 
       - name: Coding Style Checks
         run: composer test:lint

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,14 +14,14 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        php: [8.2, 8.3, 8.4]
-        laravel: [11.*, 12.*]
-        dependency-version: [prefer-stable]
+        php: ["8.2", "8.3", "8.4"]
+        laravel: ["^11.32", "^12.0.1"]
+        dependency-version: [prefer-lowest, prefer-stable]
         include:
-          - laravel: 11.*
-            testbench: 9.*
-          - laravel: 12.*
-            testbench: 10.*
+          - laravel: "^11.32"
+            testbench: "^9.5"
+          - laravel: "^12.0.1"
+            testbench: "^10.0"
 
     name: Tests P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.os }} - ${{ matrix.dependency-version }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,16 +2,24 @@ name: Tests
 
 on:
   push:
+    paths-ignore:
+      - "**.md"
+      - "docs/**"
     branches:
       - main
       - ci/test
   pull_request:
+    paths-ignore:
+      - "**.md"
+      - "docs/**"
+  schedule:
+    - cron: "0 0 * * *"
 
 jobs:
   tests:
     runs-on: ${{ matrix.os }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         php: ["8.2", "8.3", "8.4"]
@@ -23,7 +31,7 @@ jobs:
           - laravel: "^12.0.1"
             testbench: "^10.0"
 
-    name: Tests P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.os }} - ${{ matrix.dependency-version }}
+    name: PHP${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.os }} - ${{ matrix.dependency-version }}
 
     steps:
       - name: Checkout

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ To view the Persian documentation, please refer to [README_FA.md](./README_FA.md
 ## Requirements
 
 - PHP version `8.2.0` or higher
-- Laravel `11.*`, or `12.*`
+- Laravel `^11.32`, or `^12.0.1`
 
 ## List of Available SMS Providers
 

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "require": {
         "php": "^8.2",
         "spatie/laravel-package-tools": "^1.92",
-        "illuminate/contracts": "^11.0||^12.0"
+        "illuminate/contracts": "^11.32 || ^12.0.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^11.5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a98580e67212e60b141a64188135b204",
+    "content-hash": "c693ede06ac1c00a4a7e5ed84a9546a1",
     "packages": [
         {
             "name": "brick/math",


### PR DESCRIPTION
### What is the reason for this PR?

Based on the implementation method for the fake HTTP client (`Http::fakeConnection`), Laravel `11.32` is specified as the minimum required Laravel version.
Also GitHub action files are improved based on [LaraStan workflows](https://github.com/larastan/larastan/tree/3.x/.github/workflows)

- [ ] A new feature
- [x] Fixed an issue

### Author's checklist

- [x] Follow the [Contribution Guide](../CONTRIBUTING.md)
- [x] New features and changes are [documented](../README.md)

### Summary of changes

- Updated composer.json to require Laravel 11.32 as the minimum version.
- Updated CI to run on minimum version of two major versions of Laravel, `11.32` and `12.0.1`
- Updated CI to run with prefer-lowest and prefer-stable
- Updated README to reflect these versions
- Improved GitHub action files

### Review checklist

- [ ] All checks have passed
- [x] Changes are added to the `CHANGELOG.md`
- [x] Changes are approved by maintainer
