### PR TITLE
Feat: return error code

### DIFF
--- a/src/Abstracts/Driver.php
+++ b/src/Abstracts/Driver.php
@@ -104,6 +104,11 @@ abstract class Driver implements Sms
     abstract protected function getErrorMessage(): string;
 
     /**
+     * Get the error code if SMS sending failed
+     */
+    abstract protected function getErrorCode(): string|int;
+
+    /**
      * {@inheritdoc}
      *
      * @throws SmsIsImmutableException
@@ -294,7 +299,7 @@ abstract class Driver implements Sms
             return null;
         }
 
-        return $this->getErrorMessage();
+        return sprintf('Code %s - %s', $this->getErrorCode(), $this->getErrorMessage());
     }
 
     /**

--- a/src/Drivers/FakeDriver.php
+++ b/src/Drivers/FakeDriver.php
@@ -72,6 +72,14 @@ final class FakeDriver extends Driver
     }
 
     /**
+     * {@inheritdoc}
+     */
+    protected function getErrorCode(): string|int
+    {
+        return $this->response->errorCode();
+    }
+
+    /**
      * Throw a connection exception if defined by the user.
      */
     private function fakeHttpExceptionIfRequired(): void

--- a/src/Dtos/MockResponse.php
+++ b/src/Dtos/MockResponse.php
@@ -12,6 +12,7 @@ final readonly class MockResponse
     private function __construct(
         private bool $isSuccessful,
         private string $errorMessage,
+        private string|int $errorCode,
         private bool $shouldThrow,
     ) {}
 
@@ -20,15 +21,15 @@ final readonly class MockResponse
      */
     public static function successful(): self
     {
-        return new self(isSuccessful: true, errorMessage: '', shouldThrow: false);
+        return new self(isSuccessful: true, errorMessage: '', errorCode: '', shouldThrow: false);
     }
 
     /**
      * Get a mock configuration for failed SMS sending in tests.
      */
-    public static function failed(string $errorMessage): self
+    public static function failed(string $errorMessage, string|int $errorCode): self
     {
-        return new self(isSuccessful: false, errorMessage: $errorMessage, shouldThrow: false);
+        return new self(isSuccessful: false, errorMessage: $errorMessage, errorCode: $errorCode, shouldThrow: false);
     }
 
     /**
@@ -36,7 +37,7 @@ final readonly class MockResponse
      */
     public static function throw(): self
     {
-        return new self(isSuccessful: false, errorMessage: '', shouldThrow: true);
+        return new self(isSuccessful: false, errorMessage: '', errorCode: '', shouldThrow: true);
     }
 
     /**
@@ -61,5 +62,13 @@ final readonly class MockResponse
     public function errorMessage(): string
     {
         return $this->errorMessage;
+    }
+
+    /**
+     * User-defined error code for failed SMS sending.
+     */
+    public function errorCode(): string|int
+    {
+        return $this->errorCode;
     }
 }

--- a/src/Facades/Sms.php
+++ b/src/Facades/Sms.php
@@ -34,9 +34,9 @@ final class Sms extends Facade
     /**
      * Get a mock configuration for failed SMS sending in tests.
      */
-    public static function failedRequest(string $errorMessage = 'Error Message'): MockResponse
+    public static function failedRequest(string $errorMessage = 'Error Message', string|int $errorCode = 0): MockResponse
     {
-        return MockResponse::failed($errorMessage);
+        return MockResponse::failed($errorMessage, $errorCode);
     }
 
     /**

--- a/tests/Feature/Facades/SmsTest.php
+++ b/tests/Feature/Facades/SmsTest.php
@@ -33,9 +33,9 @@ final class SmsTest extends TestCase
     #[Test]
     public function it_returns_mocked_response_with_failed_condition(): void
     {
-        $mockedResponse = Sms::failedRequest('Custom error Message');
+        $mockedResponse = Sms::failedRequest('Custom error Message', 40);
 
-        $this->assertEquals(MockResponse::failed('Custom error Message'), $mockedResponse);
+        $this->assertEquals(MockResponse::failed('Custom error Message', 40), $mockedResponse);
     }
 
     #[Test]
@@ -98,7 +98,7 @@ final class SmsTest extends TestCase
     {
         $sampleDrivers = ['default', 'test_driver', 'test'];
 
-        Sms::fake($sampleDrivers, Sms::failedRequest('Custom error message'));
+        Sms::fake($sampleDrivers, Sms::failedRequest('Custom error message', 40));
 
         collect($sampleDrivers)
             ->map(fn (string $driver) => $driver === 'default' ? null : $driver)
@@ -107,7 +107,7 @@ final class SmsTest extends TestCase
 
                 $this->assertInstanceOf(FakeDriver::class, $sms);
                 $this->assertFalse($sms->successful());
-                $this->assertSame('Custom error message', $sms->error());
+                $this->assertSame('Code 40 - Custom error message', $sms->error());
             });
     }
 
@@ -139,7 +139,7 @@ final class SmsTest extends TestCase
     public function it_fakes_each_provider_with_user_specific_configuration(): void
     {
         Sms::fake([
-            'default' => Sms::failedRequest('Custom error message'),
+            'default' => Sms::failedRequest(),
             'test_driver' => Sms::successfulRequest(),
             'test' => Sms::failedConnection(),
         ]);

--- a/tests/Fixtures/TestDriver.php
+++ b/tests/Fixtures/TestDriver.php
@@ -66,4 +66,9 @@ final class TestDriver extends Driver
     {
         return 'Test error message';
     }
+
+    protected function getErrorCode(): string|int
+    {
+        return 40;
+    }
 }

--- a/tests/Fixtures/TestDriver.php
+++ b/tests/Fixtures/TestDriver.php
@@ -8,9 +8,7 @@ use AliYavari\IranSms\Abstracts\Driver;
 
 final class TestDriver extends Driver
 {
-    public string $whatIsCalled = ''; // To test
-
-    public array $receivedArguments; // To test
+    public array $dataToAssert; // To test
 
     public function __construct(
         private readonly string $from,
@@ -19,15 +17,13 @@ final class TestDriver extends Driver
 
     protected function getDefaultSender(): string
     {
-        $this->whatIsCalled = 'getDefaultSender';
-
         return $this->from;
     }
 
     protected function sendOtp(string $phone, string $message, string $from): static
     {
-        $this->whatIsCalled = 'sendOtp';
-        $this->receivedArguments = [
+        $this->dataToAssert = [
+            'type' => 'otp',
             'phone' => $phone,
             'message' => $message,
             'from' => $from,
@@ -38,8 +34,8 @@ final class TestDriver extends Driver
 
     protected function sendPattern(array $phones, string $patternCode, array $variables, string $from): static
     {
-        $this->whatIsCalled = 'sendPattern';
-        $this->receivedArguments = [
+        $this->dataToAssert = [
+            'type' => 'pattern',
             'phones' => $phones,
             'code' => $patternCode,
             'variables' => $variables,
@@ -51,8 +47,8 @@ final class TestDriver extends Driver
 
     protected function sendText(array $phones, string $message, string $from): static
     {
-        $this->whatIsCalled = 'sendText';
-        $this->receivedArguments = [
+        $this->dataToAssert = [
+            'type' => 'text',
             'phones' => $phones,
             'message' => $message,
             'from' => $from,
@@ -63,15 +59,11 @@ final class TestDriver extends Driver
 
     protected function isSuccessful(): bool
     {
-        $this->whatIsCalled = 'isSuccessful';
-
         return $this->successful;
     }
 
     protected function getErrorMessage(): string
     {
-        $this->whatIsCalled = 'getErrorMessage';
-
         return 'Test error message';
     }
 }

--- a/tests/Unit/Abstracts/DriverTest.php
+++ b/tests/Unit/Abstracts/DriverTest.php
@@ -28,7 +28,6 @@ final class DriverTest extends TestCase
         $senderNumber = $this->callProtectedMethod($sms, 'getSender');
 
         $this->assertSame('1234', $senderNumber);
-        $this->assertSame('getDefaultSender', $sms->whatIsCalled);
     }
 
     #[Test]
@@ -51,12 +50,12 @@ final class DriverTest extends TestCase
         $sms->otp('091234567', 'OTP Message')->send();
 
         $this->assertInstanceOf(TestDriver::class, $sms);
-        $this->assertSame('sendOtp', $sms->whatIsCalled);
         $this->assertSame([
+            'type' => 'otp',
             'phone' => '091234567',
             'message' => 'OTP Message',
             'from' => '1234',
-        ], $sms->receivedArguments);
+        ], $sms->dataToAssert);
     }
 
     #[Test]
@@ -79,13 +78,13 @@ final class DriverTest extends TestCase
         $sms->pattern('091234567', 'pattern_code', ['key' => 'value'])->send();
 
         $this->assertInstanceOf(TestDriver::class, $sms);
-        $this->assertSame('sendPattern', $sms->whatIsCalled);
         $this->assertSame([
+            'type' => 'pattern',
             'phones' => ['091234567'],
             'code' => 'pattern_code',
             'variables' => ['key' => 'value'],
             'from' => '1234',
-        ], $sms->receivedArguments);
+        ], $sms->dataToAssert);
     }
 
     #[Test]
@@ -108,12 +107,12 @@ final class DriverTest extends TestCase
         $sms->text('091234567', 'Text Message')->send();
 
         $this->assertInstanceOf(TestDriver::class, $sms);
-        $this->assertSame('sendText', $sms->whatIsCalled);
         $this->assertSame([
+            'type' => 'text',
             'phones' => ['091234567'],
             'message' => 'Text Message',
             'from' => '1234',
-        ], $sms->receivedArguments);
+        ], $sms->dataToAssert);
     }
 
     #[Test]
@@ -134,7 +133,7 @@ final class DriverTest extends TestCase
         $this->getAllSmsTypes(from: '1234')->each(function (TestDriver $sms) {
             $sms->from('4567')->send();
 
-            $this->assertSame('4567', $sms->receivedArguments['from']);
+            $this->assertSame('4567', $sms->dataToAssert['from']);
         });
     }
 
@@ -157,14 +156,12 @@ final class DriverTest extends TestCase
         $sms->otp('091234567', 'OTP Message')->send();
 
         $this->assertTrue($sms->successful());
-        $this->assertSame('isSuccessful', $sms->whatIsCalled);
 
         // Failed
         $sms = $this->sms(successful: false);
         $sms->otp('091234567', 'OTP Message')->send();
 
         $this->assertFalse($sms->successful());
-        $this->assertSame('isSuccessful', $sms->whatIsCalled);
     }
 
     #[Test]
@@ -187,14 +184,12 @@ final class DriverTest extends TestCase
         $sms->otp('091234567', 'OTP Message')->send();
 
         $this->assertFalse($sms->failed());
-        $this->assertSame('isSuccessful', $sms->whatIsCalled);
 
         // Failed
         $sms = $this->sms(successful: false);
         $sms->otp('091234567', 'OTP Message')->send();
 
         $this->assertTrue($sms->failed());
-        $this->assertSame('isSuccessful', $sms->whatIsCalled);
     }
 
     #[Test]
@@ -216,14 +211,6 @@ final class DriverTest extends TestCase
         $sms->otp('091234567', 'OTP Message')->send();
 
         $this->assertNull($sms->error());
-        /**
-         * ------------------
-         * Logic Explanation:
-         * ------------------
-         * We are not sure if `getErrorMessage` on the driver class, can handle successful status,
-         * So we need to make sure this method won't be called in the successful status.
-         */
-        $this->assertNotSame('getErrorMessage', $sms->whatIsCalled);
     }
 
     #[Test]
@@ -233,7 +220,6 @@ final class DriverTest extends TestCase
         $sms->otp('091234567', 'OTP Message')->send();
 
         $this->assertSame('Test error message', $sms->error());
-        $this->assertSame('getErrorMessage', $sms->whatIsCalled);
     }
 
     #[Test]

--- a/tests/Unit/Abstracts/DriverTest.php
+++ b/tests/Unit/Abstracts/DriverTest.php
@@ -219,7 +219,7 @@ final class DriverTest extends TestCase
         $sms = $this->sms(successful: false);
         $sms->otp('091234567', 'OTP Message')->send();
 
-        $this->assertSame('Test error message', $sms->error());
+        $this->assertSame('Code 40 - Test error message', $sms->error());
     }
 
     #[Test]
@@ -359,7 +359,7 @@ final class DriverTest extends TestCase
         $logsCount = SmsLog::query()
             ->where('from', '1234')
             ->where('is_successful', false)
-            ->where('error', 'Test error message')
+            ->where('error', 'Code 40 - Test error message')
             ->count();
 
         $this->assertSame(3, $logsCount);

--- a/tests/Unit/Drivers/FakeDriverTest.php
+++ b/tests/Unit/Drivers/FakeDriverTest.php
@@ -26,12 +26,13 @@ final class FakeDriverTest extends TestCase
     #[Test]
     public function it_returns_failed_statues_and_error(): void
     {
-        $driver = $this->driver(MockResponse::failed('Our Custom Error'));
+        $driver = $this->driver(MockResponse::failed('Our Custom Error', 40));
 
         $this->sendAllSmsTypes($driver); // Should be without any error
 
         $this->assertFalse($this->callProtectedMethod($driver, 'isSuccessful'));
         $this->assertSame('Our Custom Error', $this->callProtectedMethod($driver, 'getErrorMessage'));
+        $this->assertSame(40, $this->callProtectedMethod($driver, 'getErrorCode'));
     }
 
     #[Test]


### PR DESCRIPTION
### What is the reason for this PR?

This PR adds error codes to the returned error messages, allowing users to debug more effectively and communicate issues with their SMS provider's support teams.

- [x] A new feature
- [ ] Fixed an issue (resolve #ID)

### Author's checklist

- [x] Follow the [Contribution Guide](../CONTRIBUTING.md)
- [x] New features and changes are [documented](../README.md)

### Summary of changes

- Added error code to error responses.
- Updated the fake driver to support custom error codes in tests.

### Review checklist

- [ ] All checks have passed
- [ ] Changes are added to the `CHANGELOG.md`
- [ ] Changes are approved by maintainer
