### PR TITLE
Feat: add prune logs command

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,18 @@ You can chain the logging methods to define custom logic fluently:
 $sms->log()->logOtp(false)->logSuccessful();
 ```
 
+#### Prune Old Logs
+
+To help keep your log table clean, this package provides an Artisan command to prune old log records. You can schedule this command using [Laravel's task scheduler]
+
+Example: Delete logs created before 30 days ago
+
+```php
+use Illuminate\Support\Facades\Schedule;
+
+Schedule::command('iran-sms:prune-logs --days=30')->daily();
+```
+
 ### Sending SMS
 
 To send the SMS:
@@ -276,7 +288,7 @@ final class MyNotification extends Notification
     }
 
     /**
-     * Get the voice representation of the notification.
+     * Get the SMS representation of the notification.
      */
     public function toSms(object $notifiable)
     {
@@ -292,23 +304,38 @@ This package provides fluent methods to fake and test SMS sending:
 ```php
 use AliYavari\IranSms\Facades\Sms;
 
-// Fake the default provider to return successful responses
+/**
+ * Fake the default provider to return successful response
+ */
 Sms::fake();
 
-// Fake specific providers to return successful responses
-// Note: Use `default` as the provider key to target the default provider
+/**
+ * Fake specific providers to return successful responses
+ *
+ * Note: Use `default` as the provider key to target the default provider
+ */
 Sms::fake([/* provider keys */]);
 
-// Equivalent to the above (explicit success)
+/**
+ * Equivalent to the above (explicit success definition)
+ */
 Sms::fake([...], Sms::successfulRequest());
 
-// Fake providers to return failed responses (optional custom error message)
-Sms::fake([...], Sms::failedRequest(string $errorMessage = 'Error Message'));
+/**
+ * Fake providers to return failed responses
+ *
+ * Optional: custom error message and error code
+ */
+Sms::fake([...], Sms::failedRequest(string $errorMessage = 'Error Message', string|int $errorCode = 0));
 
-// Fake providers to throw a ConnectionException
+/**
+ * Fake providers to throw a ConnectionException
+ */
 Sms::fake([...], Sms::failedConnection());
 
-// Define different behaviors per provider
+/**
+ * Define different behaviors per provider
+ */
 Sms::fake([
     'provider_one' => Sms::failedConnection(),
     'provider_two' => Sms::failedRequest(),
@@ -338,3 +365,4 @@ Thank you for considering contributing to the Iran SMS Laravel! The contribution
 [HTTP Client]: https://laravel.com/docs/12.x/http-client#throwing-exceptions
 [queues]: https://laravel.com/docs/12.x/queues
 [notifications]: https://laravel.com/docs/12.x/notifications
+[Laravel's task scheduler]: https://laravel.com/docs/12.x/scheduling#scheduling-artisan-commands

--- a/src/Commands/PruneLogsCommand.php
+++ b/src/Commands/PruneLogsCommand.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AliYavari\IranSms\Commands;
+
+use AliYavari\IranSms\Models\SmsLog;
+use Illuminate\Console\Command;
+
+/**
+ * @internal
+ *
+ * Command to prune old records from the sms_logs table.
+ */
+final class PruneLogsCommand extends Command
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected $signature = 'iran-sms:prune-logs {--days=30 : The number of days to retain SMS logs}';
+
+    /**
+     * {@inheritdoc}
+     */
+    protected $description = 'Prune SMS logs created before the specified number of days';
+
+    /**
+     * {@inheritdoc}
+     */
+    public function handle(): int
+    {
+        $days = (int) $this->option('days');
+
+        $this->components->task(
+            "Pruning logs created before {$days} days ago ...",
+            fn () => SmsLog::where('created_at', '<', now()->subDays($days))->delete()
+        );
+
+        $this->components->info("Logs created before [{$days} days] ago pruned successfully.");
+
+        return 0;
+    }
+}

--- a/src/IranSmsServiceProvider.php
+++ b/src/IranSmsServiceProvider.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace AliYavari\IranSms;
 
+use AliYavari\IranSms\Commands\PruneLogsCommand;
 use Illuminate\Foundation\Application;
 use Spatie\LaravelPackageTools\Commands\InstallCommand;
 use Spatie\LaravelPackageTools\Package;
@@ -19,6 +20,7 @@ final class IranSmsServiceProvider extends PackageServiceProvider
         $package->name('iran-sms')
             ->hasConfigFile()
             ->hasMigration('create_sms_logs_table')
+            ->hasCommand(PruneLogsCommand::class)
             ->hasInstallCommand(function (InstallCommand $command) {
                 $command
                     ->publishConfigFile()

--- a/src/Models/SmsLog.php
+++ b/src/Models/SmsLog.php
@@ -8,6 +8,8 @@ use AliYavari\IranSms\Enums\Type;
 use Illuminate\Database\Eloquent\Model;
 
 /**
+ * @internal
+ *
  * @property-read int $id
  * @property-read Type $type
  * @property-read string $driver

--- a/tests/Unit/Commands/PruneLogsCommandTest.php
+++ b/tests/Unit/Commands/PruneLogsCommandTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AliYavari\IranSms\Tests\Unit\Commands;
+
+use AliYavari\IranSms\Enums\Type;
+use AliYavari\IranSms\Models\SmsLog;
+use AliYavari\IranSms\Tests\TestCase;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
+
+final class PruneLogsCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[Test]
+    public function it_delete_logs_based_on_created_at_time(): void
+    {
+        Carbon::setTestNow('2025-07-01 5:00:00');
+
+        $this->createSmsLog('2025-06-30 5:00:00', 'log_1');
+        $this->createSmsLog('2025-06-29 4:59:00', 'log_2'); // More than 2 days ago
+        $this->createSmsLog('2025-07-03 5:00:00', 'log_3');
+        $this->createSmsLog('2025-07-01 5:00:00', 'log_4');
+
+        $this->artisan('iran-sms:prune-logs --days=2')
+            ->expectsOutputToContain('Logs created before [2 days] ago pruned successfully.');
+
+        $this->assertDatabaseMissing(SmsLog::class, ['driver' => 'log_2']); // The 'driver' field is used to store the log name.
+        $this->assertDatabaseHas(SmsLog::class, ['driver' => 'log_1']);
+        $this->assertDatabaseHas(SmsLog::class, ['driver' => 'log_3']);
+        $this->assertDatabaseHas(SmsLog::class, ['driver' => 'log_4']);
+
+        Carbon::setTestNow();
+    }
+
+    // -----------------
+    // Helper Methods
+    // -----------------
+
+    private function createSmsLog(string $createdAt, string $name): SmsLog
+    {
+        $smsLog = new SmsLog([
+            'type' => fake()->randomElement(Type::cases()),
+            'driver' => $name,
+            'from' => '12345',
+            'to' => ['123'],
+            'content' => ['message' => 'Hi'],
+            'is_successful' => fake()->boolean(),
+            'error' => fake()->randomElement([null, 'Error Message']),
+        ]);
+
+        $smsLog->created_at = $createdAt;
+        $smsLog->save();
+
+        return $smsLog;
+    }
+}


### PR DESCRIPTION
### What is the reason for this PR?

This PR add `iran-sms:prune-logs` artisan command to help users easily keep their `sms_logs` table clean.

- [x] A new feature
- [ ] Fixed an issue (resolve #ID)

### Author's checklist

- [ ] Follow the [Contribution Guide](../CONTRIBUTING.md)
- [ ] New features and changes are [documented](../README.md)

### Summary of changes

- Added `iran-sms:prune-logs` artisan command
- Documented new feature in `README.md`
- Polished `README.md` content to clarify them

### Review checklist

- [ ] All checks have passed
- [ ] Changes are added to the `CHANGELOG.md`
- [ ] Changes are approved by maintainer
