### PR TITLE
Refactor: separate sending and logging SMS

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use Rector\CodeQuality\Rector\Isset_\IssetOnPropertyObjectToPropertyExistsRector;
 use Rector\CodingStyle\Rector\Encapsed\EncapsedStringsToSprintfRector;
 use Rector\CodingStyle\Rector\Use_\SeparateMultiUseImportsRector;
 use Rector\Config\RectorConfig;
@@ -9,6 +10,7 @@ use Rector\Php83\Rector\ClassMethod\AddOverrideAttributeToOverriddenMethodsRecto
 use Rector\PHPUnit\CodeQuality\Rector\MethodCall\AssertEmptyNullableObjectToAssertInstanceofRector;
 use Rector\Strict\Rector\BooleanNot\BooleanInBooleanNotRuleFixerRector;
 use Rector\TypeDeclaration\Rector\ArrowFunction\AddArrowFunctionReturnTypeRector;
+use Rector\TypeDeclaration\Rector\ClassMethod\AddMethodCallBasedStrictParamTypeRector;
 use Rector\TypeDeclaration\Rector\Closure\AddClosureNeverReturnTypeRector;
 use Rector\TypeDeclaration\Rector\Closure\AddClosureVoidReturnTypeWhereNoReturnRector;
 use Rector\TypeDeclaration\Rector\Closure\ClosureReturnTypeRector;
@@ -47,4 +49,6 @@ return RectorConfig::configure()
         SeparateMultiUseImportsRector::class,
         EncapsedStringsToSprintfRector::class,
         AssertEmptyNullableObjectToAssertInstanceofRector::class,
+        IssetOnPropertyObjectToPropertyExistsRector::class,
+        AddMethodCallBasedStrictParamTypeRector::class => [__DIR__.'/tests'],
     ]);

--- a/src/Concerns/HasLog.php
+++ b/src/Concerns/HasLog.php
@@ -1,0 +1,201 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AliYavari\IranSms\Concerns;
+
+use AliYavari\IranSms\Enums\Type;
+use AliYavari\IranSms\Models\SmsLog;
+use Illuminate\Support\Str;
+use ReflectionClass;
+
+/**
+ * @internal
+ *
+ * Handles logging operations related to SMS sending.
+ * Provides implementations for log methods defined in the
+ * \AliYavari\IranSms\Contracts\Sms interface.
+ *
+ * Core Method:
+ * - handleLog(): Handle SMS log operation.
+ *
+ * This trait relies on the following methods and properties
+ * provided by the consuming class:
+ *
+ * @method ?string error()
+ * @method bool successful()
+ * @method string getSender()
+ * @method list<string> ensureIsArray(string|list<string> $phones)
+ *
+ * @property Type $type
+ * @property string|list<string> $phones
+ * @property string|array<mixed> $content
+ * @property string $patternCode
+ */
+trait HasLog
+{
+    /**
+     * Which types must be logged
+     *
+     * @var list<Type>
+     */
+    private array $typesToLog;
+
+    /**
+     * Which statuses must be logged
+     *
+     * @var list<string>
+     */
+    private array $statusesToLog = ['successful', 'failed'];
+
+    /**
+     * {@inheritdoc}
+     */
+    final public function log(bool $log = true): static
+    {
+        $this->typesToLog = $log ? Type::cases() : [];
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    final public function logOtp(bool $log = true): static
+    {
+        $log ? $this->addTypeToLog(Type::Otp) : $this->removeTypeFromLog(Type::Otp);
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    final public function logPattern(bool $log = true): static
+    {
+        $log ? $this->addTypeToLog(Type::Pattern) : $this->removeTypeFromLog(Type::Pattern);
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    final public function logText(bool $log = true): static
+    {
+        $log ? $this->addTypeToLog(Type::Text) : $this->removeTypeFromLog(Type::Text);
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    final public function logSuccessful(): static
+    {
+        if (! isset($this->typesToLog)) {
+            $this->log(true);
+        }
+
+        $this->statusesToLog = ['successful'];
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    final public function logFailed(): static
+    {
+        if (! isset($this->typesToLog)) {
+            $this->log(true);
+        }
+
+        $this->statusesToLog = ['failed'];
+
+        return $this;
+    }
+
+    /**
+     * Handle log based on the user setup
+     */
+    private function handleLog(): void
+    {
+        if (! isset($this->typesToLog) || $this->typesToLog === []) {
+            return;
+        }
+
+        if (! in_array($this->type, $this->typesToLog, strict: true)) {
+            return;
+        }
+
+        $statusText = $this->successful() ? 'successful' : 'failed';
+
+        if (! in_array($statusText, $this->statusesToLog, strict: true)) {
+            return;
+        }
+
+        $this->storeLog();
+    }
+
+    /**
+     * Store SMS log
+     */
+    private function storeLog(): void
+    {
+        SmsLog::query()->create([
+            'type' => $this->type,
+            'driver' => $this->getDriverName(),
+            'from' => $this->getSender(),
+            'to' => $this->ensureIsArray($this->phones),
+            'content' => $this->serializeContent(),
+            'is_successful' => $this->successful(),
+            'error' => $this->error(),
+        ]);
+    }
+
+    /**
+     * Serialize content of SMS to save in the Database
+     *
+     * @return array<string, mixed>
+     */
+    private function serializeContent(): array
+    {
+        return is_string($this->content)
+        ? ['message' => $this->content]
+        : ['code' => $this->patternCode, 'variables' => $this->content];
+    }
+
+    /**
+     * Get driver name from class name
+     */
+    private function getDriverName(): string
+    {
+        $class = new ReflectionClass(static::class);
+
+        return Str::of($class->getShortName())
+            ->before('Driver')
+            ->snake()
+            ->toString();
+    }
+
+    /**
+     * Add SMS type to be logged
+     */
+    private function addTypeToLog(Type $type): void
+    {
+        $this->typesToLog ??= [];
+
+        $this->typesToLog = collect($this->typesToLog)->push($type)->unique()->all();
+    }
+
+    /**
+     * Remove SMS type from being logged
+     */
+    private function removeTypeFromLog(Type $type): void
+    {
+        $this->typesToLog ??= [];
+
+        $this->typesToLog = collect($this->typesToLog)->reject(fn (Type $value) => $value === $type)->all();
+    }
+}

--- a/tests/Fixtures/ConcreteTestDriver.php
+++ b/tests/Fixtures/ConcreteTestDriver.php
@@ -6,7 +6,13 @@ namespace AliYavari\IranSms\Tests\Fixtures;
 
 use AliYavari\IranSms\Abstracts\Driver;
 
-final class TestDriver extends Driver
+/**
+ * Test fixture class for the `Driver` abstract class.
+ *
+ * This class implements the required methods expected by
+ * the `Driver` abstract class for isolated testing purposes.
+ */
+final class ConcreteTestDriver extends Driver
 {
     public array $dataToAssert; // To test
 

--- a/tests/Fixtures/HasLogTestDriver.php
+++ b/tests/Fixtures/HasLogTestDriver.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AliYavari\IranSms\Tests\Fixtures;
+
+use AliYavari\IranSms\Concerns\HasLog;
+use AliYavari\IranSms\Enums\Type;
+
+/**
+ * Test fixture class for the `HasLog` trait.
+ *
+ * This class implements the required properties and methods
+ * expected by the `HasLog` trait for isolated testing purposes.
+ */
+final class HasLogTestDriver
+{
+    use HasLog;
+
+    public function __construct(
+        private readonly Type $type,
+        private readonly string $phones,
+        private readonly array|string $content,
+        private readonly ?string $patternCode,
+        private readonly bool $successful,
+        private readonly ?string $error,
+        private readonly string $sender,
+    ) {}
+
+    public function successful(): bool
+    {
+        return $this->successful;
+    }
+
+    public function error(): ?string
+    {
+        return $this->error;
+    }
+
+    public function callHandleLog(): void
+    {
+        $this->handleLog();
+    }
+
+    private function getSender(): string
+    {
+        return $this->sender;
+    }
+
+    private function ensureIsArray(string|array $phones): array
+    {
+        return [$phones];
+    }
+}

--- a/tests/Unit/Concerns/HasLogTest.php
+++ b/tests/Unit/Concerns/HasLogTest.php
@@ -1,0 +1,366 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AliYavari\IranSms\Tests\Unit\Concerns;
+
+use AliYavari\IranSms\Concerns\HasLog;
+use AliYavari\IranSms\Enums\Type;
+use AliYavari\IranSms\Models\SmsLog;
+use AliYavari\IranSms\Tests\Fixtures\HasLogTestDriver;
+use AliYavari\IranSms\Tests\TestCase;
+use Illuminate\Support\Collection;
+use Mockery;
+use PHPUnit\Framework\Attributes\Test;
+
+final class HasLogTest extends TestCase
+{
+    #[Test]
+    public function it_serialize_string_message_successfully(): void
+    {
+        // Otp
+        $sms = $this->sms(Type::Otp, '091234567', 'OTP Message');
+
+        $content = $this->callProtectedMethod($sms, 'serializeContent');
+
+        $this->assertSame(['message' => 'OTP Message'], $content);
+
+        // text
+        $sms = $this->sms(Type::Text, '091234567', 'Text Message');
+
+        $content = $this->callProtectedMethod($sms, 'serializeContent');
+
+        $this->assertSame(['message' => 'Text Message'], $content);
+    }
+
+    #[Test]
+    public function it_serialize_pattern_message_successfully(): void
+    {
+        $sms = $this->sms(Type::Pattern, '091234567', ['key' => 'value'], 'pattern_code');
+
+        $content = $this->callProtectedMethod($sms, 'serializeContent');
+
+        $this->assertSame([
+            'code' => 'pattern_code',
+            'variables' => ['key' => 'value'],
+        ], $content);
+    }
+
+    #[Test]
+    public function it_returns_driver_name(): void
+    {
+        /**
+         * ------------------
+         * Logic Explanation:
+         * ------------------
+         * Uses name convention of driver's class: *\CustomNameDriver => `custom_name`
+         */
+        $sms = Mockery::namedMock('\Class\Namespace\CustomNameDriver', HasLog::class);
+
+        $driverName = $this->callProtectedMethod($sms, 'getDriverName');
+
+        $this->assertSame('custom_name', $driverName);
+    }
+
+    #[Test]
+    public function it_logs_otp_message_successfully(): void
+    {
+        $sms = $this->sms(Type::Otp, '091234567', 'OTP Message');
+
+        $this->callProtectedMethod($sms, 'storeLog');
+
+        $this->assertDatabaseHas(SmsLog::class, [
+            'type' => Type::Otp,
+            'to' => json_encode(['091234567']),
+            'content' => json_encode($this->callProtectedMethod($sms, 'serializeContent')),  // This is not this test's concern.
+        ]);
+    }
+
+    #[Test]
+    public function it_logs_text_message_successfully(): void
+    {
+        $sms = $this->sms(Type::Text, '091234567', 'Text Message');
+
+        $this->callProtectedMethod($sms, 'storeLog');
+
+        $this->assertDatabaseHas(SmsLog::class, [
+            'type' => Type::Text,
+            'to' => json_encode(['091234567']),
+            'content' => json_encode($this->callProtectedMethod($sms, 'serializeContent')),  // This is not this test's concern.
+        ]);
+    }
+
+    #[Test]
+    public function it_logs_pattern_message_successfully(): void
+    {
+        $sms = $this->sms(Type::Pattern, '091234567', ['key' => 'value'], 'pattern_code');
+
+        $this->callProtectedMethod($sms, 'storeLog');
+
+        $this->assertDatabaseHas(SmsLog::class, [
+            'type' => Type::Pattern,
+            'to' => json_encode(['091234567']),
+            'content' => json_encode($this->callProtectedMethod($sms, 'serializeContent')),  // This is not this test's concern.
+        ]);
+    }
+
+    #[Test]
+    public function it_logs_all_types_with_successful_status_successfully(): void
+    {
+        $this->getAllSmsTypes(from: '1234', successful: true, error: null)->each(function (HasLogTestDriver $sms) {
+            $this->callProtectedMethod($sms, 'storeLog');
+        });
+
+        $logsCount = SmsLog::query()
+            ->where('from', '1234')
+            ->where('is_successful', true)
+            ->whereNull('error')
+            ->count();
+
+        $this->assertSame(3, $logsCount);
+    }
+
+    #[Test]
+    public function it_logs_all_types_with_failed_status_successfully(): void
+    {
+        $this->getAllSmsTypes(from: '1234', successful: false, error: 'Test error message')->each(function (HasLogTestDriver $sms) {
+            $this->callProtectedMethod($sms, 'storeLog');
+        });
+
+        $logsCount = SmsLog::query()
+            ->where('from', '1234')
+            ->where('is_successful', false)
+            ->where('error', 'Test error message')
+            ->count();
+
+        $this->assertSame(3, $logsCount);
+    }
+
+    #[Test]
+    public function it_does_not_log_anything_if_user_did_not_set_log_config(): void
+    {
+        $this->getAllSmsTypes()->each(function (HasLogTestDriver $sms) {
+            $sms->callHandleLog();
+        });
+
+        $this->assertDatabaseEmpty(SmsLog::class);
+    }
+
+    #[Test]
+    public function it_does_not_log_anything_if_user_sets_log_to_false_for_all_types(): void
+    {
+        $this->getAllSmsTypes()->each(function (HasLogTestDriver $sms) {
+            $sms->log(false)->callHandleLog();
+        });
+
+        $this->assertDatabaseEmpty(SmsLog::class);
+    }
+
+    #[Test]
+    public function it_logs_everything_if_user_sets_log_all(): void
+    {
+        $this->getAllSmsTypes()->each(function (HasLogTestDriver $sms) {
+            $sms->log(true)->callHandleLog();
+        });
+
+        $this->assertDatabaseCount(SmsLog::class, 3);
+    }
+
+    #[Test]
+    public function it_logs_only_otp_messages_if_user_sets_log_to_only_otp(): void
+    {
+        $this->getAllSmsTypes()->each(function (HasLogTestDriver $sms) {
+            $sms->logOtp(true)->callHandleLog();
+        });
+
+        $this->getAllSmsTypes()->each(function (HasLogTestDriver $sms) {
+            $sms->log(false)->logOtp(true)->callHandleLog();
+        });
+
+        $otpLogs = SmsLog::query()->where('type', Type::Otp)->count();
+
+        $this->assertSame(2, $otpLogs);
+        $this->assertDatabaseCount(SmsLog::class, 2);
+    }
+
+    #[Test]
+    public function it_does_not_log_otp_message_if_user_sets_it_not_to_log_otp(): void
+    {
+        $sms = $this->sms(Type::Otp, '091234567', 'OTP Message');
+        $sms->log(true)->logOtp(false)->callHandleLog();
+
+        $this->assertDatabaseEmpty(SmsLog::class);
+    }
+
+    #[Test]
+    public function it_logs_only_text_messages_if_user_sets_log_to_only_text(): void
+    {
+        $this->getAllSmsTypes()->each(function (HasLogTestDriver $sms) {
+            $sms->logText(true)->callHandleLog();
+        });
+
+        $this->getAllSmsTypes()->each(function (HasLogTestDriver $sms) {
+            $sms->log(false)->logText(true)->callHandleLog();
+        });
+
+        $textLogs = SmsLog::query()->where('type', Type::Text)->count();
+
+        $this->assertSame(2, $textLogs);
+        $this->assertDatabaseCount(SmsLog::class, 2);
+    }
+
+    #[Test]
+    public function it_does_not_log_text_message_if_user_sets_it_not_to_log_text(): void
+    {
+        $sms = $this->sms(Type::Text, '091234567', 'Text Message');
+        $sms->log(true)->logText(false)->callHandleLog();
+
+        $this->assertDatabaseEmpty(SmsLog::class);
+    }
+
+    #[Test]
+    public function it_logs_only_pattern_messages_if_user_sets_log_to_only_pattern(): void
+    {
+        $this->getAllSmsTypes()->each(function (HasLogTestDriver $sms) {
+            $sms->logPattern(true)->callHandleLog();
+        });
+
+        $this->getAllSmsTypes()->each(function (HasLogTestDriver $sms) {
+            $sms->log(false)->logPattern(true)->callHandleLog();
+        });
+
+        $patternLogs = SmsLog::query()->where('type', Type::Pattern)->count();
+
+        $this->assertSame(2, $patternLogs);
+        $this->assertDatabaseCount(SmsLog::class, 2);
+    }
+
+    #[Test]
+    public function it_does_not_log_pattern_message_if_user_sets_it_not_to_log_pattern(): void
+    {
+        $sms = $this->sms(Type::Pattern, '091234567', ['key' => 'value'], 'pattern_code');
+        $sms->log(true)->logPattern(false)->callHandleLog();
+
+        $this->assertDatabaseEmpty(SmsLog::class);
+    }
+
+    #[Test]
+    public function it_only_logs_successful_messages_if_user_sets_it_to_log_successful(): void
+    {
+        // Must be logged
+        $this->getAllSmsTypes(successful: true)->each(function (HasLogTestDriver $sms) {
+            $sms->log(true)->logSuccessful()->callHandleLog();
+        });
+
+        // Won't log
+        $this->getAllSmsTypes(successful: false)->each(function (HasLogTestDriver $sms) {
+            $sms->log(true)->logSuccessful()->callHandleLog();
+        });
+
+        $successfulLogs = SmsLog::query()->where('is_successful', true)->count();
+
+        $this->assertSame(3, $successfulLogs);
+        $this->assertDatabaseCount(SmsLog::class, 3);
+    }
+
+    #[Test]
+    public function it_calls_log_if_user_did_not_call_type_logs_before_only_successful_log(): void
+    {
+        $this->getAllSmsTypes(successful: true)->each(function (HasLogTestDriver $sms) {
+            $sms->logSuccessful()->callHandleLog();
+        });
+
+        $this->assertDatabaseCount(SmsLog::class, 3);
+    }
+
+    #[Test]
+    public function it_will_not_call_log_if_user_called_type_logs_before_only_successful_log(): void
+    {
+        $this->getAllSmsTypes(successful: true)->each(function (HasLogTestDriver $sms) {
+            $sms->log(false)->logSuccessful()->callHandleLog();
+        });
+
+        $this->getAllSmsTypes(successful: true)->each(function (HasLogTestDriver $sms) {
+            $sms->logOtp(false)->logSuccessful()->callHandleLog();
+        });
+
+        $this->getAllSmsTypes(successful: true)->each(function (HasLogTestDriver $sms) {
+            $sms->logPattern(false)->logSuccessful()->callHandleLog();
+        });
+
+        $this->getAllSmsTypes(successful: true)->each(function (HasLogTestDriver $sms) {
+            $sms->logText(false)->logSuccessful()->callHandleLog();
+        });
+
+        $this->assertDatabaseEmpty(SmsLog::class);
+    }
+
+    #[Test]
+    public function it_only_logs_failed_messages_if_user_sets_it_to_log_failed(): void
+    {
+        // Must be logged
+        $this->getAllSmsTypes(successful: false)->each(function (HasLogTestDriver $sms) {
+            $sms->log(true)->logFailed()->callHandleLog();
+        });
+
+        // Won't log
+        $this->getAllSmsTypes(successful: true)->each(function (HasLogTestDriver $sms) {
+            $sms->log(true)->logFailed()->callHandleLog();
+        });
+
+        $failedLogs = SmsLog::query()->where('is_successful', false)->count();
+
+        $this->assertSame(3, $failedLogs);
+        $this->assertDatabaseCount(SmsLog::class, 3);
+    }
+
+    #[Test]
+    public function it_calls_log_if_user_did_not_call_type_logs_before_only_failed_log(): void
+    {
+        $this->getAllSmsTypes(successful: false)->each(function (HasLogTestDriver $sms) {
+            $sms->logFailed()->callHandleLog();
+        });
+
+        $this->assertDatabaseCount(SmsLog::class, 3);
+    }
+
+    #[Test]
+    public function it_will_not_call_log_if_user_called_type_logs_before_only_failed_log(): void
+    {
+        $this->getAllSmsTypes(successful: false)->each(function (HasLogTestDriver $sms) {
+            $sms->log(false)->logSuccessful()->callHandleLog();
+        });
+
+        $this->getAllSmsTypes(successful: false)->each(function (HasLogTestDriver $sms) {
+            $sms->logOtp(false)->logSuccessful()->callHandleLog();
+        });
+
+        $this->getAllSmsTypes(successful: false)->each(function (HasLogTestDriver $sms) {
+            $sms->logPattern(false)->logSuccessful()->callHandleLog();
+        });
+
+        $this->getAllSmsTypes(successful: false)->each(function (HasLogTestDriver $sms) {
+            $sms->logText(false)->logSuccessful()->callHandleLog();
+        });
+
+        $this->assertDatabaseEmpty(SmsLog::class);
+    }
+
+    // -----------------
+    // Helper Methods
+    // -----------------
+
+    private function sms($type, $phones, $content, $patternCode = null, $successful = true, $error = null, $callHandleLoger = '123'): HasLogTestDriver
+    {
+        return new HasLogTestDriver($type, $phones, $content, $patternCode, $successful, $error, $callHandleLoger);
+    }
+
+    private function getAllSmsTypes($from = '123', $successful = true, $error = null): Collection
+    {
+        return collect([
+            $this->sms(Type::Text, '091234567', 'Text Message', null, $successful, $error, $from),
+            $this->sms(Type::Otp, '091234567', 'OTP Message', null, $successful, $error, $from),
+            $this->sms(Type::Pattern, '091234567', ['key' => 'value'], 'pattern_code', $successful, $error, $from),
+        ]);
+    }
+}

--- a/tests/Unit/SmsManagerTest.php
+++ b/tests/Unit/SmsManagerTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace AliYavari\IranSms\Tests\Unit;
 
 use AliYavari\IranSms\SmsManager;
-use AliYavari\IranSms\Tests\Fixtures\TestDriver;
+use AliYavari\IranSms\Tests\Fixtures\ConcreteTestDriver;
 use AliYavari\IranSms\Tests\TestCase;
 use Illuminate\Support\Facades\Config;
 use PHPUnit\Framework\Attributes\Test;
@@ -31,13 +31,13 @@ final class SmsManagerTest extends TestCase
     #[Test]
     public function it_sets_custom_instance_as_driver_instance(): void
     {
-        $testDriver = new TestDriver('123456', true);
+        $testDriver = new ConcreteTestDriver('123456', true);
 
         $this->smsManager()->setDriver('test_driver', $testDriver);
 
         $retrievedDriver = $this->smsManager()->driver('test_driver');
 
-        $this->assertInstanceOf(TestDriver::class, $retrievedDriver);
+        $this->assertInstanceOf(ConcreteTestDriver::class, $retrievedDriver);
         $this->assertSame('123456', $this->callProtectedMethod($retrievedDriver, 'getDefaultSender'));
     }
 


### PR DESCRIPTION
### What is the reason for this PR?

This PR separates logging and sending logic to adhere to single responsibility principle better.

- [x] A new feature
- [ ] Fixed an issue

### Author's checklist

- [x] Follow the [Contribution Guide](../CONTRIBUTING.md)
- [x] New features and changes are [documented](../README.md)

### Summary of changes

- Moved logging logic to `HasLog` trait.
- Separated tests, made testing logging and sending more independent.
- Managed Rector rules to avoid make code more complex

### Review checklist

- [ ] All checks have passed
- [ ] Changes are added to the `CHANGELOG.md`
- [ ] Changes are approved by maintainer
