### PR TITLE
fix: correct status check for WebOne driver after discovering API docs were wrong

### DIFF
--- a/src/Drivers/WebOneDriver.php
+++ b/src/Drivers/WebOneDriver.php
@@ -21,7 +21,7 @@ final class WebOneDriver extends Driver
     private string $baseUrl = 'https://api.payamakapi.ir/api/v1';
 
     /**
-     * The sent status returned in the API response body (e.g., `Succeeded` field).
+     * The sent status returned in the API response body (e.g., `succeeded` field).
      */
     private bool $apiStatus;
 
@@ -148,7 +148,7 @@ final class WebOneDriver extends Driver
             ->throw()
             ->json();
 
-        $this->apiStatus = (bool) $response['Succeeded'];
+        $this->apiStatus = (bool) $response['succeeded'];
         $this->apiStatusCode = (int) $response['resultCode'];
     }
 }

--- a/tests/Unit/Drivers/WebOneDriverTest.php
+++ b/tests/Unit/Drivers/WebOneDriverTest.php
@@ -27,7 +27,7 @@ final class WebOneDriverTest extends TestCase
     public function it_execute_request_correctly(): void
     {
         Http::fake([
-            'https://api.payamakapi.ir/api/v1/end-point' => Http::response(['Succeeded' => true, 'resultCode' => 0]),
+            'https://api.payamakapi.ir/api/v1/end-point' => Http::response(['succeeded' => true, 'resultCode' => 0]),
         ]);
 
         $smsDriver = $this->driver();
@@ -44,7 +44,7 @@ final class WebOneDriverTest extends TestCase
     public function it_sets_and_returns_the_successful_response_status_correctly(): void
     {
         Http::fake([
-            'https://api.payamakapi.ir/api/v1/end-point' => Http::response(['Succeeded' => true, 'resultCode' => 0]),
+            'https://api.payamakapi.ir/api/v1/end-point' => Http::response(['succeeded' => true, 'resultCode' => 0]),
         ]);
 
         $smsDriver = $this->driver();
@@ -58,7 +58,7 @@ final class WebOneDriverTest extends TestCase
     public function it_sets_and_returns_the_failed_response_status_correctly(): void
     {
         Http::fake([
-            'https://api.payamakapi.ir/api/v1/end-point' => Http::response(['Succeeded' => false, 'resultCode' => 1]),
+            'https://api.payamakapi.ir/api/v1/end-point' => Http::response(['succeeded' => false, 'resultCode' => 1]),
         ]);
 
         $smsDriver = $this->driver();
@@ -85,7 +85,7 @@ final class WebOneDriverTest extends TestCase
     #[Test]
     public function it_sends_text_message_successfully(): void
     {
-        Http::fake(['*' => Http::response(['Succeeded' => false, 'resultCode' => 1])]);
+        Http::fake(['*' => Http::response(['succeeded' => false, 'resultCode' => 1])]);
 
         $this->callProtectedMethod($this->driver(), 'sendText', [['0913', '0914'], 'Text message', '4567']);
 
@@ -98,7 +98,7 @@ final class WebOneDriverTest extends TestCase
     #[Test]
     public function it_sends_otp_message_successfully(): void
     {
-        Http::fake(['*' => Http::response(['Succeeded' => false, 'resultCode' => 1])]);
+        Http::fake(['*' => Http::response(['succeeded' => false, 'resultCode' => 1])]);
 
         $this->callProtectedMethod($this->driver(), 'sendOtp', ['0913', 'Otp message', '4567']);
 


### PR DESCRIPTION
### What is the reason for this PR?

This PR fixes status check for `Web One SMS` based on real-world tests and founding out that API docs were wrong.

- [ ] A new feature
- [x] Fixed an issue

### Author's checklist

- [x] Follow the [Contribution Guide](../CONTRIBUTING.md)
- [x] New features and changes are [documented](../README.md)

### Summary of changes

- Changed implementation of checking API status for `Web One SMS` provider.

### Review checklist

- [x] All checks have passed
- [x] Changes are added to the `CHANGELOG.md`
- [x] Changes are approved by maintainer
