### PR TITLE
Fix: creating immutable SMS instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+
+- Ensure a new immutable SMS instance is created for each message.
+
 ## [1.1.0] - 2025-07-16
 
 ### Added
@@ -35,5 +41,6 @@ Supported Providers:
 - Faraz SMS
 - Raygan SMS
 
-[1.0.0]: https://github.com/amyavari/iran-sms-laravel/compare/v0.1.0...v1.0.0
+[Unreleased]: https://github.com/amyavari/iran-sms-laravel/compare/v1.1.0...HEAD
 [1.1.0]: https://github.com/amyavari/iran-sms-laravel/compare/v1.0.0...v1.1.0
+[1.0.0]: https://github.com/amyavari/iran-sms-laravel/compare/v0.1.0...v1.0.0

--- a/tests/Unit/SmsManagerTest.php
+++ b/tests/Unit/SmsManagerTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace AliYavari\IranSms\Tests\Unit;
 
 use AliYavari\IranSms\Drivers\AmootSmsDriver;
+use AliYavari\IranSms\Drivers\FakeDriver;
 use AliYavari\IranSms\Drivers\FarazSmsDriver;
 use AliYavari\IranSms\Drivers\KavenegarDriver;
 use AliYavari\IranSms\Drivers\MeliPayamakDriver;
@@ -37,16 +38,26 @@ final class SmsManagerTest extends TestCase
     }
 
     #[Test]
-    public function it_sets_custom_instance_as_driver_instance(): void
+    public function it_sets_custom_fake_driver_instance_as_driver_instance(): void
     {
-        $testDriver = new ConcreteTestDriver('123456', true);
+        $testDriver = $this->mock(FakeDriver::class);
 
         $this->smsManager()->setDriver('test_driver', $testDriver);
 
         $retrievedDriver = $this->smsManager()->driver('test_driver');
 
-        $this->assertInstanceOf(ConcreteTestDriver::class, $retrievedDriver);
-        $this->assertSame('123456', $this->callProtectedMethod($retrievedDriver, 'getDefaultSender'));
+        $this->assertSame($testDriver, $retrievedDriver);
+    }
+
+    #[Test]
+    public function it_always_returns_new_instance_of_sms_driver_class_for_immutability(): void
+    {
+        $this->smsManager()->extend('test_driver', fn () => new ConcreteTestDriver('123456', true));
+
+        $instanceOne = $this->smsManager()->driver('test_driver');
+        $instanceTwo = $this->smsManager()->driver('test_driver');
+
+        $this->assertNotSame($instanceOne, $instanceTwo);
     }
 
     #[Test]


### PR DESCRIPTION
### What is the reason for this PR?

Ensure a new immutable SMS instance is created for each message.

- [ ] A new feature
- [x] Fixed an issue

### Author's checklist

- [x] Follow the [Contribution Guide](../CONTRIBUTING.md)
- [x] New features and changes are [documented](../README.md)

### Summary of changes

- Fixed SMS instance management - now properly creates new immutable instances each time 

### Review checklist

- [ ] All checks have passed
- [ ] Changes are added to the `CHANGELOG.md`
- [ ] Changes are approved by maintainer
