### PR TITLE
Build: remove path version constraint for dependencies

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,12 +23,12 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         php: ["8.2", "8.3", "8.4"]
-        laravel: ["^11.35", "^12.0.1"]
+        laravel: ["^11.35", "^12.0"]
         dependency-version: [prefer-lowest, prefer-stable]
         include:
           - laravel: "^11.35"
             testbench: "^9.6.1"
-          - laravel: "^12.0.1"
+          - laravel: "^12.0"
             testbench: "^10.0"
 
     name: PHP${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.os }} - ${{ matrix.dependency-version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Removed
+
+- `composer.lock`.
+- Patch version constraints from dependencies.
+
 ## [1.2.0] - 2025-10-13
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "require": {
         "php": "^8.2",
         "spatie/laravel-package-tools": "^1.92",
-        "illuminate/contracts": "^11.35.1 || ^12.0.1"
+        "illuminate/contracts": "^11.35 || ^12.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^11.5",


### PR DESCRIPTION
### What is the reason for this PR?

This PR, removes path version constraints from dependencies to avoid unnecessary conflicts.

- [ ] A new feature
- [x] Fixed an issue (resolve #ID)

### Author's checklist

- [x] Follow the [Contribution Guide](../CONTRIBUTING.md)
- [x] New features and changes are [documented](../README.md)

### Summary of changes

- Removed path version constraints for `illuminate/contracts`

### Review checklist

- [ ] All checks have passed
- [ ] Changes are added to the `CHANGELOG.md`
- [ ] Changes are approved by maintainer
