### PR TITLE
ci: force bash shell to prevent Windows `^` escaping

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -59,6 +59,7 @@ jobs:
       - name: Install Laravel version
         run: |
           composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update --dev
+        shell: bash
 
       - name: Install Composer dependencies
         run: composer update --${{ matrix.dependency-version }} --no-interaction --prefer-dist


### PR DESCRIPTION
### What is the reason for this PR?

This PR forces the `composer require` command on CI tests to run in bash (`Git Bash` on Windows) on all OSes to avoid Windows escaping `^` in package version constraints.

- [ ] A new feature
- [x] Fixed an issue

### Author's checklist

- [ ] Follow the [Contribution Guide](../CONTRIBUTING.md)
- [ ] New features and changes are [documented](../README.md)

### Summary of changes

- Forces `composer require` common to run in bash on CI tests.

### Review checklist

- [ ] All checks have passed
- [ ] Changes are added to the `CHANGELOG.md`
- [ ] Changes are approved by maintainer
