### PR TITLE
test: change fake http response body to be compatible with accepated types

### DIFF
--- a/tests/Unit/Drivers/RayganSmsDriverTest.php
+++ b/tests/Unit/Drivers/RayganSmsDriverTest.php
@@ -139,7 +139,7 @@ final class RayganSmsDriverTest extends TestCase
     #[Test]
     public function it_sends_otp_message_successfully(): void
     {
-        Http::fake(['*' => Http::response(2001)]); // Greater than 2000 is successful
+        Http::fake(['*' => Http::response('2001')]); // Greater than 2000 is successful
 
         $smsDriver = $this->driver();
 
@@ -162,7 +162,7 @@ final class RayganSmsDriverTest extends TestCase
     #[Test]
     public function it_sends_otp_message_with_error(): void
     {
-        Http::fake(['*' => Http::response(8)]);
+        Http::fake(['*' => Http::response('8')]);
 
         $smsDriver = $this->driver();
 

--- a/tests/Unit/Drivers/WebOneDriverTest.php
+++ b/tests/Unit/Drivers/WebOneDriverTest.php
@@ -120,7 +120,7 @@ final class WebOneDriverTest extends TestCase
     #[Test]
     public function it_returns_credit_successfully(): void
     {
-        Http::fake(['*' => Http::response(1000.4)]);
+        Http::fake(['*' => Http::response('1000.4')]);
 
         $credit = $this->driver()->credit();
 


### PR DESCRIPTION
### What is the reason for this PR?

This PR updates fake HTTP response body type to accepted types. From `int` to `string`

- [ ] A new feature
- [x] Fixed an issue

### Author's checklist

- [ ] Follow the [Contribution Guide](../CONTRIBUTING.md)
- [ ] New features and changes are [documented](../README.md)

### Summary of changes

- Updated fake HTTP resposne body types from `int` to `string`

### Review checklist

- [ ] All checks have passed
- [ ] Changes are added to the `CHANGELOG.md`
- [ ] Changes are approved by maintainer
